### PR TITLE
Make size and font public on MSAvatarSize

### DIFF
--- a/OfficeUIFabric/People Picker/MSAvatarView.swift
+++ b/OfficeUIFabric/People Picker/MSAvatarView.swift
@@ -15,7 +15,7 @@ import UIKit
     case xLarge
     case xxLarge
 
-    var font: UIFont {
+    public var font: UIFont {
         switch self {
         case .xSmall:
             return UIFont.systemFont(ofSize: 9)
@@ -32,7 +32,7 @@ import UIKit
         }
     }
 
-    var size: CGSize {
+    public var size: CGSize {
         switch self {
         case .xSmall:
             return CGSize(width: 18, height: 18)


### PR DESCRIPTION
These are not usable currently from outside the module. This allows consumers of OfficeUIFabric
SDK to use MSAvatarSize options with other services that require CGSize or UIFont.