### PR TITLE
Moves MSNotificationView actionButton target-action set out of initializer block

### DIFF
--- a/OfficeUIFabric/Notification/MSNotificationView.swift
+++ b/OfficeUIFabric/Notification/MSNotificationView.swift
@@ -151,7 +151,6 @@ open class MSNotificationView: UIView {
         actionButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: Constants.horizontalSpacing, bottom: 0, right: Constants.horizontalPadding)
         actionButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         actionButton.setContentHuggingPriority(.required, for: .horizontal)
-        actionButton.addTarget(self, action: #selector(handleActionButtonTap), for: .touchUpInside)
         return actionButton
     }()
     private let separator = MSSeparator(style: .shadow, orientation: .horizontal)
@@ -201,6 +200,8 @@ open class MSNotificationView: UIView {
         accessibilityElements = [container, actionButton]
 
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleMessageTap)))
+
+        actionButton.addTarget(self, action: #selector(handleActionButtonTap), for: .touchUpInside)
 
         messageLabelBoundsObservation = messageLabel.observe(\.bounds) { [unowned self] (_, _) in
             self.updateVerticalPadding()


### PR DESCRIPTION
Using the value of ```self``` inside Swift property initialization closures shouldn't work. Sometimes you can use it (it seems to work fine in the demo project) but sometimes it doesn't work correctly. See https://bugs.swift.org/browse/SR-4559?jql=text%20~%20%22self%20function%22.

This is causing ```handleActionButtonTap``` not to fire the target-action I a project I'm working on even though the notification action button is receiving taps. I'm not sure why the demo project works. 

An alternative solution would be to make this property a lazy var so it doesn't get set up until after super.init completes and self is configured, but I like that these are lets since they're not meant to be changed once the notification is created.

See https://stackoverflow.com/questions/49491028/swift-self-in-variable-initialization-closure for more information.