### PR TITLE
Expose preferred content width and height

### DIFF
--- a/OfficeUIFabric/Drawer/MSDrawerController.swift
+++ b/OfficeUIFabric/Drawer/MSDrawerController.swift
@@ -282,8 +282,8 @@ open class MSDrawerController: UIViewController {
         }
     }
     // Override to provide the preferred size based on specifics of the concrete drawer subclass (see popup menu, for example)
-    var preferredContentWidth: CGFloat { return 0 }
-    var preferredContentHeight: CGFloat { return 0 }
+    open var preferredContentWidth: CGFloat { return 0 }
+    open var preferredContentHeight: CGFloat { return 0 }
     var tracksContentHeight: Bool {
         guard presentationController is UIPopoverPresentationController || presentationDirection.isVertical else {
             return false

--- a/OfficeUIFabric/Popup Menu/MSPopupMenuController.swift
+++ b/OfficeUIFabric/Popup Menu/MSPopupMenuController.swift
@@ -26,7 +26,7 @@ open class MSPopupMenuController: MSDrawerController {
     open override var resizingBehavior: MSDrawerResizingBehavior { get { return .dismiss } set { } }
 
     open override var preferredContentSize: CGSize { get { return super.preferredContentSize } set { } }
-    override var preferredContentWidth: CGFloat {
+    open override var preferredContentWidth: CGFloat {
         var width = Constants.minimumContentWidth
         if let headerItem = headerItem {
             if !descriptionView.isHidden {
@@ -44,7 +44,7 @@ open class MSPopupMenuController: MSDrawerController {
         }
         return width
     }
-    override var preferredContentHeight: CGFloat {
+    open override var preferredContentHeight: CGFloat {
         var height: CGFloat = 0
         if let headerItem = headerItem {
             if !descriptionView.isHidden {


### PR DESCRIPTION
When subclassing `MSDrawerController` in an app, I followed the example of `MSPopupMenuController`, but came to issues when setting the size.

I was able to use `preferredContentSize` initially, but this caused an error with the rendering (the content would not be visible and the drag handle would jump around when dismissing interactively). 

So instead I tried to override `preferredContentWidth` and `preferredContentHeight` as is done in `MSPopupMenuController`, but wasn't able to as these properties were not declared as `open`.

This PR exposes those properties with the `open` keyword.